### PR TITLE
SLING-12639 - Enable Cluster Awareness for DistributionSubscriber (#158)

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
+++ b/src/main/java/org/apache/sling/distribution/journal/impl/subscriber/DistributionSubscriber.java
@@ -73,6 +73,7 @@ import org.apache.sling.distribution.journal.messages.OffsetMessage;
 import org.apache.sling.distribution.journal.messages.PackageMessage;
 import org.apache.sling.distribution.journal.messages.PackageStatusMessage;
 import org.apache.sling.distribution.journal.shared.Delay;
+import org.apache.sling.distribution.journal.shared.OnlyOnLeader;
 import org.apache.sling.distribution.journal.shared.Topics;
 import org.apache.sling.distribution.packaging.DistributionPackageBuilder;
 import org.apache.sling.settings.SlingSettingsService;
@@ -124,6 +125,9 @@ public class DistributionSubscriber {
 
     @Reference
     private SubscriberReadyStore subscriberReadyStore;
+
+    @Reference
+    private OnlyOnLeader onlyOnLeader;
 
     private SubscriberMetrics subscriberMetrics;
 

--- a/src/main/java/org/apache/sling/distribution/journal/shared/OnlyOnLeader.java
+++ b/src/main/java/org/apache/sling/distribution/journal/shared/OnlyOnLeader.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal.shared;
+
+import org.apache.sling.discovery.TopologyEvent;
+import org.apache.sling.discovery.TopologyEventListener;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Hashtable;
+
+import static org.apache.sling.discovery.TopologyEvent.Type.*;
+
+/**
+ * Marker service to register services to enable components
+ * only on the leader within a cluster. To leverage it,
+ * add a reference to <code>OnlyOnLeader</code> in your
+ * services that must only run on the leader within a cluster.
+ *
+ */
+@Component(immediate = true, service = TopologyEventListener.class)
+public class OnlyOnLeader implements TopologyEventListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OnlyOnLeader.class);
+
+    private final BundleContext context;
+
+    private ServiceRegistration<OnlyOnLeader> reg;
+
+    @Activate
+    public OnlyOnLeader(BundleContext context) {
+        this.context = context;
+    }
+
+    @Deactivate
+    public void deactivate() {
+        unregister();
+    }
+
+    @Override
+    public void handleTopologyEvent(TopologyEvent event) {
+        TopologyEvent.Type eventType = event.getType();
+        if (eventType == TOPOLOGY_INIT || eventType == TOPOLOGY_CHANGED) {
+            if (event.getNewView().getLocalInstance().isLeader()) {
+                register();
+            } else {
+                unregister();
+            }
+        } else if (eventType == TOPOLOGY_CHANGING) {
+            unregister();
+        }
+    }
+
+    synchronized boolean isLeader() {
+        return reg != null;
+    }
+
+    private synchronized void register() {
+        if (reg == null) {
+            LOG.info("Registering OnlyOnLeader service");
+            reg = context.registerService(OnlyOnLeader.class, this, new Hashtable<>());
+        } else {
+            LOG.debug("Service OnlyOnLeader already registered");
+        }
+    }
+
+    private synchronized void unregister() {
+        if (reg != null) {
+            LOG.info("Unregistering OnlyOnLeader service");
+            reg.unregister();
+            reg = null;
+        } else {
+            LOG.debug("No OnlyOnLeader service to unregister");
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/distribution/journal/shared/OnlyOnLeaderTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/shared/OnlyOnLeaderTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal.shared;
+
+import org.apache.sling.discovery.InstanceDescription;
+import org.apache.sling.discovery.TopologyEvent;
+import org.apache.sling.discovery.TopologyEvent.Type;
+import org.apache.sling.discovery.TopologyView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import static org.apache.sling.discovery.TopologyEvent.Type.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OnlyOnLeaderTest {
+
+    @Mock
+    private BundleContext context;
+
+    @Mock
+    private ServiceRegistration<OnlyOnLeader> reg;
+
+    @InjectMocks
+    private OnlyOnLeader onlyOnLeader;
+
+    @Before
+    public void before () {
+        when(context.registerService(eq(OnlyOnLeader.class), any(OnlyOnLeader.class), any()))
+                .thenReturn(reg);
+    }
+
+    @Test
+    public void testServiceRegistration() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        verify(context).registerService(eq(OnlyOnLeader.class), eq(onlyOnLeader), any());
+        assertTrue(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testDoubleServiceRegistration() {
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        assertTrue(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        assertTrue(onlyOnLeader.isLeader());
+        verify(context, times(1)).registerService(eq(OnlyOnLeader.class), eq(onlyOnLeader), any());
+    }
+
+    @Test
+    public void testServiceDeRegistration() {
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        assertTrue(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGING, true));
+        verify(reg).unregister();
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyChangedOnLeader() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        assertTrue(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyChangingOnLeader() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGING, true));
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyInitOnLeader() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_INIT, true));
+        assertTrue(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyChangedOnFollower() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, false));
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyChangingOnFollower() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGING, false));
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testTopologyInitOnFollower() {
+        assertFalse(onlyOnLeader.isLeader());
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_INIT, false));
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    @Test
+    public void testDeactivate() {
+        onlyOnLeader.handleTopologyEvent(topologyEvent(TOPOLOGY_CHANGED, true));
+        assertTrue(onlyOnLeader.isLeader());
+        onlyOnLeader.deactivate();
+        assertFalse(onlyOnLeader.isLeader());
+    }
+
+    private TopologyEvent topologyEvent(Type eventType, boolean isLeader) {
+        InstanceDescription instanceDescription = mock(InstanceDescription.class);
+        when(instanceDescription.isLeader()).thenReturn(isLeader);
+        final TopologyView newView;
+        if (eventType != TOPOLOGY_CHANGING) {
+            newView = mock(TopologyView.class);
+            when(newView.getLocalInstance()).thenReturn(instanceDescription);
+        } else {
+            newView = null;
+        }
+        final TopologyView oldView;
+        if (eventType != TOPOLOGY_INIT) {
+            oldView = mock(TopologyView.class);
+        } else {
+            oldView = null;
+        }
+        return new TopologyEvent(eventType, oldView, newView);
+    }
+}


### PR DESCRIPTION
* Add OnlyOnLeader marker service
* Ensure the DistributionSubscriber is only active on the leader instance